### PR TITLE
docs: add missing code backticks

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,11 +116,14 @@ The reformulator would improve it to:
 ```
 What should be considered in presence of bilateral and symmetric alveolar syndrome, perihilar, often with effusion?
 {{c1::In case of bilateral and symmetric alveolar syndrome, perihilar, often with effusion, one should consider APE.}}
+```
 
 The reformulator can also make cards more concise when needed. For example, it could reformat the same card as:
 
+```
 Key features of bilateral and symmetric alveolar syndrome, perihilar, often with effusion:
 - {{c1::Consider APE}}
+```
 
 The true power of the reformulator lies in its flexibility - your imagination is the only limit. It can:
 - Make questions grammatically complete and clear


### PR DESCRIPTION
There were a couple of missing backticks in the readme that meant Mnemonics and Explainer info was hidden inside the details of the Reformulator.