### PR TITLE
feat: add MiniMax-M3 as the latest LLM option

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,14 +245,14 @@ The tools use [LiteLLM](https://docs.litellm.ai/docs/) which provides a unified 
 - OpenAI
 - Anthropic
 - Google
-- [MiniMax](https://www.minimaxi.com/) (MiniMax-M2.7, MiniMax-M2.7-highspeed — 204K context)
+- [MiniMax](https://www.minimaxi.com/) (MiniMax-M3 — 512K context, MiniMax-M2.7, MiniMax-M2.7-highspeed — 204K context)
 - OpenRouter
 - Azure
 - AWS Bedrock
 - Local models
 - And many more
 
-Just specify the model in LiteLLM format (e.g. "openai/gpt-4", "anthropic/claude-3-opus", or "minimax/MiniMax-M2.7") and it will handle the rest. For MiniMax, place your API key in a file named `MINIMAX` inside the `API_KEYS/` directory (the tools will load it as `MINIMAX_API_KEY`).
+Just specify the model in LiteLLM format (e.g. "openai/gpt-4", "anthropic/claude-3-opus", or "minimax/MiniMax-M3") and it will handle the rest. For MiniMax, place your API key in a file named `MINIMAX` inside the `API_KEYS/` directory (the tools will load it as `MINIMAX_API_KEY`).
 
 ### What languages are supported?
 The tools work in any language supported by the LLM you choose to use. Since these scripts support virtually all LLM providers through LiteLLM, you can use any model that works well with your language. For example:

--- a/tests/test_minimax.py
+++ b/tests/test_minimax.py
@@ -20,6 +20,7 @@ class TestMiniMaxRegistration(unittest.TestCase):
         from utils.llm import _register_minimax
         _register_minimax()
         self.assertIn("minimax", litellm.models_by_provider)
+        self.assertIn("MiniMax-M3", litellm.models_by_provider["minimax"])
         self.assertIn("MiniMax-M2.7", litellm.models_by_provider["minimax"])
         self.assertIn(
             "MiniMax-M2.7-highspeed", litellm.models_by_provider["minimax"]
@@ -29,8 +30,10 @@ class TestMiniMaxRegistration(unittest.TestCase):
         import litellm
         from utils.llm import _register_minimax
         _register_minimax()
+        self.assertIn("minimax/MiniMax-M3", litellm.model_cost)
         self.assertIn("minimax/MiniMax-M2.7", litellm.model_cost)
         self.assertIn("minimax/MiniMax-M2.7-highspeed", litellm.model_cost)
+        self.assertIn("MiniMax-M3", litellm.model_cost)
         self.assertIn("MiniMax-M2.7", litellm.model_cost)
         self.assertIn("MiniMax-M2.7-highspeed", litellm.model_cost)
 
@@ -45,6 +48,18 @@ class TestMiniMaxRegistration(unittest.TestCase):
         self.assertGreater(cost["input_cost_per_token"], 0)
         self.assertGreater(cost["output_cost_per_token"], 0)
         self.assertEqual(cost["max_tokens"], 204800)
+
+    def test_m3_pricing_and_context(self):
+        """MiniMax-M3 should be registered with 512K context and correct pricing."""
+        import litellm
+        from utils.llm import _register_minimax
+        _register_minimax()
+        cost = litellm.model_cost["minimax/MiniMax-M3"]
+        self.assertEqual(cost["max_tokens"], 524288)
+        self.assertEqual(cost["max_input_tokens"], 524288)
+        self.assertEqual(cost["max_output_tokens"], 131072)
+        self.assertGreater(cost["input_cost_per_token"], 0)
+        self.assertGreater(cost["output_cost_per_token"], 0)
 
     def test_register_minimax_idempotent(self):
         """Calling _register_minimax() multiple times should not error."""

--- a/tests/test_minimax_integration.py
+++ b/tests/test_minimax_integration.py
@@ -20,6 +20,26 @@ MINIMAX_API_KEY = os.environ.get("MINIMAX_API_KEY", "")
 class TestMiniMaxIntegration(unittest.TestCase):
     """Integration tests that call the live MiniMax API."""
 
+    def test_chat_minimax_m3(self):
+        """Test a basic chat completion with MiniMax-M3."""
+        from utils.llm import MINIMAX_API_BASE
+        from litellm import completion
+
+        response = completion(
+            model="openai/MiniMax-M3",
+            messages=[{"role": "user", "content": "Say hello in one word."}],
+            temperature=0.5,
+            api_base=MINIMAX_API_BASE,
+            api_key=MINIMAX_API_KEY,
+            stream=False,
+        )
+        result = response.json()
+        self.assertIn("choices", result)
+        self.assertGreater(len(result["choices"]), 0)
+        content = result["choices"][0]["message"]["content"]
+        self.assertIsInstance(content, str)
+        self.assertGreater(len(content), 0)
+
     def test_chat_minimax_m27(self):
         """Test a basic chat completion with MiniMax-M2.7."""
         from utils.llm import MINIMAX_API_BASE

--- a/utils/llm.py
+++ b/utils/llm.py
@@ -22,6 +22,14 @@ litellm.drop_params = True
 MINIMAX_API_BASE = "https://api.minimax.io/v1"
 
 MINIMAX_MODELS = {
+    "MiniMax-M3": {
+        "max_tokens": 524288,
+        "max_input_tokens": 524288,
+        "max_output_tokens": 131072,
+        "input_cost_per_token": 0.0000006,
+        "output_cost_per_token": 0.0000024,
+        "litellm_provider": "openai",
+    },
     "MiniMax-M2.7": {
         "max_tokens": 204800,
         "max_input_tokens": 204800,


### PR DESCRIPTION
## Summary
Register the new MiniMax-M3 model alongside the existing M2.7 / M2.7-highspeed entries so users can opt in to M3 from LiteLLM right away.

## Changes
- `utils/llm.py`: add `MiniMax-M3` to `MINIMAX_MODELS` with 524288 context / 131072 max output and `$0.6 / $2.4` per 1M token pricing.
- `README.md`: list M3 first in the MiniMax bullet (512K context) and use `minimax/MiniMax-M3` as the LiteLLM example string.
- `tests/test_minimax.py`: assert M3 is registered in `litellm.models_by_provider` and `litellm.model_cost`; add a dedicated test for M3 pricing/context.
- `tests/test_minimax_integration.py`: add a live API test for `openai/MiniMax-M3` (skipped without `MINIMAX_API_KEY`, matching the existing M2.7 test).

## Why
MiniMax-M3 is the new flagship model with a 512K context window, 128K max output and image input support. Existing M2.7 / M2.7-highspeed entries are retained for backward compatibility, so this is a strictly additive change.

## Testing
- `python -m unittest tests.test_minimax -v` -> 18 tests pass (including the new `test_m3_pricing_and_context`).
- Integration test scaffolding for M3 mirrors the existing M2.7 test; live verification skipped here due to lack of API credit on the dev key, but the same code path is already exercised by the unmodified M2.7 integration test.